### PR TITLE
Add GitHub workflow to run composite action

### DIFF
--- a/.github/workflows/run-action.yml
+++ b/.github/workflows/run-action.yml
@@ -1,0 +1,15 @@
+name: Check Merge Commits
+
+on: [push, pull_request]
+
+jobs:
+  check-merge-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Forbid Merge Commits Action
+        uses: ./

--- a/README.md
+++ b/README.md
@@ -8,3 +8,6 @@ For more guidance on handling merge commits and this action's failure messages, 
 
 ## Handling Failure Messages
 If this action fails due to the presence of merge commits, it will print out the offending commits and fail the workflow. This is an indication that the pull request contains merge commits that are not allowed. To resolve this, you can either rebase your branch onto the base branch or consult the section above on when it's safe to ignore or remove this action. For further assistance, refer to [this explanation](#when-to-ignore-or-remove-this-action).
+
+## GitHub Workflow
+A GitHub workflow has been added to run the composite action against the repository itself. This workflow is defined in `.github/workflows/run-action.yml` and its purpose is to ensure that the repository adheres to its own rules against merge commits.


### PR DESCRIPTION
This pull request introduces a new GitHub workflow and updates the README.md to reflect this addition.

- **Adds a GitHub workflow**: A new file, `.github/workflows/run-action.yml`, has been created to run the composite action defined in `action.yml` against this repository. This workflow triggers on both push and pull request events and includes steps to checkout the code with a full commit history (`fetch-depth: 0`) before running the composite action.
- **Updates README.md**: The documentation now includes a section titled "GitHub Workflow" that explains the purpose of the new workflow file and its role in ensuring the repository adheres to its own rules against merge commits.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/motlin/forbid-merge-commits-action?shareId=27584e56-5cad-43a1-9e3e-eef21a3d445a).