### PR TITLE
Update README and workflow to suggest triggering on pull_request

### DIFF
--- a/.github/workflows/run-action.yml
+++ b/.github/workflows/run-action.yml
@@ -1,6 +1,6 @@
 name: Check Merge Commits
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   check-merge-commits:

--- a/README.md
+++ b/README.md
@@ -11,3 +11,21 @@ If this action fails due to the presence of merge commits, it will print out the
 
 ## GitHub Workflow
 A GitHub workflow has been added to run the composite action against the repository itself. This workflow is defined in `.github/workflows/run-action.yml` and its purpose is to ensure that the repository adheres to its own rules against merge commits.
+
+## How to Add This Action to Your Repository
+To add this action to your repository, you need to create a new workflow file in the `.github/workflows/` directory of your repository. Here is a simple example of how to set up the workflow:
+
+```yaml
+name: Enforce No Merge Commits
+on: pull_request
+jobs:
+  forbid-merge-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Run Forbid Merge Commits Action
+        uses: <your-username>/forbid-merge-commits-action@main
+```
+
+Triggering this action exclusively on `pull_request` events ensures that your repository's pull requests are checked for merge commits before they can be merged. This helps maintain a clean and linear history, which is beneficial for navigating the project's history and understanding the changes made over time.


### PR DESCRIPTION
Updates the README.md and modifies the `.github/workflows/run-action.yml` to align with the task of adding instructions for repository integration and adjusting the trigger event for the action.

- **README.md Changes**:
  - Adds a new section titled "## How to Add This Action to Your Repository" providing detailed instructions for adding the action to a repository. This includes creating a new workflow file in the `.github/workflows/` directory and configuring it to trigger on `pull_request` events. The benefits of triggering exclusively on `pull_request` events are explained, emphasizing the maintenance of a clean and linear history.
  
- **Workflow File Modification**:
  - Adjusts the `on` section in `.github/workflows/run-action.yml` to trigger exclusively on `pull_request` events, removing the previously included `push` trigger. This change ensures that the action checks for merge commits only in pull requests, aligning with the best practices outlined in the README.md update.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/motlin/forbid-merge-commits-action?shareId=6a676417-5dd5-4ebb-abf8-8dd94aeada19).