### PR TITLE
Fix shared action for forked pull requests

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,11 +12,9 @@ runs:
       run: |
         set -Eexuo pipefail
 
-        git fetch origin ${{github.base_ref}}:${{github.base_ref}} ${{github.head_ref}}:${{github.head_ref}}
-
-        if [ -n "$(git log --merges ${{github.base_ref}}..${{github.head_ref}} --)" ]; then
+        if [ -n "$(git log --merges origin/${{github.base_ref}}..${{github.sha}}^2 --)" ]; then
           echo "Failure: Found merge commits. Please refer to the README.md for guidance."
-          git log --merges ${{github.base_ref}}..${{github.head_ref}} --
+          git log --merges origin/${{github.base_ref}}..${{github.sha}}^2 --
           exit 1
         else
           echo "Success: No merge commits found"


### PR DESCRIPTION
Updates the action to correctly handle pull requests from forks.
- Removes the `git fetch origin` command to streamline the process.
- Modifies the `git log` commands to compare `origin/${{github.base_ref}}..${{github.sha}}^2`, ensuring accurate detection of merge commits in the context of forked repositories.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/motlin/forbid-merge-commits-action?shareId=bdaa44cc-eb47-4170-8a34-e6b3fbdd9fc5).