### PR TITLE
Update failure message to include README URL

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ runs:
         git fetch origin ${{github.base_ref}}:${{github.base_ref}} ${{github.head_ref}}:${{github.head_ref}}
 
         if [ -n "$(git log --merges ${{github.base_ref}}..${{github.head_ref}} --)" ]; then
-          echo "Failure: Found merge commits. Please refer to the README.md for guidance."
+          echo "Failure: Found merge commits. Please refer to https://github.com/motlin/forbid-merge-commits-action/blob/main/README.md for guidance."
           git log --merges ${{github.base_ref}}..${{github.head_ref}} --
           exit 1
         else


### PR DESCRIPTION
Updates the failure message in `action.yml` to provide a direct URL to the README.md for guidance.
- Replaces the generic reference to "README.md" in the failure message with a specific URL: "https://github.com/motlin/forbid-merge-commits-action/blob/main/README.md". This change aims to direct users more precisely to the guidance document in case of failure due to merge commits.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/motlin/forbid-merge-commits-action?shareId=59c8093d-432d-4d00-be50-e03b0348802c).