### PR TITLE
Update README to use correct action reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run Forbid Merge Commits Action
-        uses: <your-username>/forbid-merge-commits-action@main
+        uses: motlin/forbid-merge-commits-action@main
 ```
 
 Triggering this action exclusively on `pull_request` events ensures that your repository's pull requests are checked for merge commits before they can be merged. This helps maintain a clean and linear history, which is beneficial for navigating the project's history and understanding the changes made over time.


### PR DESCRIPTION
Updates the README.md to reflect the correct usage of the forbid-merge-commits-action.

- Replaces `<your-username>/forbid-merge-commits-action@main` with `motlin/forbid-merge-commits-action@main` in the "How to Add This Action to Your Repository" section to ensure users reference the correct repository when adding the action to their workflows.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/motlin/forbid-merge-commits-action?shareId=d1191210-81bd-4ebf-9ba7-82568adbc10e).