### PR TITLE
Annotate merge commits with GitHub error annotations

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,9 +12,12 @@ runs:
       run: |
         set -Eeuo pipefail
 
-        if [ -n "$(git log --merges origin/${{github.base_ref}}..refs/remotes/pull/${{github.event.pull_request.number}}/merge^2 --)" ]; then
+        MERGE_COMMITS=$(git log --merges --format=%H origin/${{github.base_ref}}..refs/remotes/pull/${{github.event.pull_request.number}}/merge^2 --)
+        if [ -n "$MERGE_COMMITS" ]; then
           echo "Failure: Found merge commits. Please refer to https://github.com/motlin/forbid-merge-commits-action#handling-failure-messages for guidance."
-          git log --merges origin/${{github.base_ref}}..refs/remotes/pull/${{github.event.pull_request.number}}/merge^2 --
+          for COMMIT_HASH in $MERGE_COMMITS; do
+            echo "::error::Merge commit found: $COMMIT_HASH"
+          done
           exit 1
         else
           echo "Success: No merge commits found"


### PR DESCRIPTION
Modifies the action to create GitHub error annotations for each merge commit found.

- **Iterates through merge commits**: Replaces the previous check for merge commits with a loop that iterates over each merge commit found, using `git log --merges --format=%H`.
- **Generates error annotations**: For each merge commit, echoes a GitHub error annotation in the format `::error::Merge commit found: $COMMIT_HASH`, providing direct feedback in the GitHub Actions interface.
- **Removes previous echo statement**: The echo statement that previously printed out the merge commits has been removed, streamlining the output to focus on the error annotations.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/motlin/forbid-merge-commits-action?shareId=41c313e9-0452-40a7-81d4-2469d53905a8).