### PR TITLE
Enhance error reporting with GitHub annotation groups

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,10 @@ runs:
         if [ -n "$MERGE_COMMITS" ]; then
           echo "Failure: Found merge commits. Please refer to https://github.com/motlin/forbid-merge-commits-action#handling-failure-messages for guidance."
           for COMMIT_HASH in $MERGE_COMMITS; do
+            echo "::group::Merge commit $COMMIT_HASH"
             echo "::error::Merge commit found: $COMMIT_HASH"
+            git show $COMMIT_HASH
+            echo "::endgroup::"
           done
           exit 1
         else


### PR DESCRIPTION
Implements GitHub annotation groups for merge commits and displays commit details using `git show`.

- **Enhances error reporting:** For each merge commit found, the script now creates a GitHub annotation group. This makes the error messages more organized and easier to navigate.
- **Displays commit details:** Inside each annotation group, the script runs `git show` on the corresponding merge commit to display its details, providing more context for the error.
- **Maintains existing functionality:** The script continues to print a general failure message when merge commits are found and a success message when no merge commits are detected.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/motlin/forbid-merge-commits-action?shareId=87cbb42d-57e7-457b-832b-5beb255679bf).