### PR TITLE
Add summary of found merge commits to GitHub step summary

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,9 +18,11 @@ runs:
           for COMMIT_HASH in $MERGE_COMMITS; do
             echo "::group::Merge commit $COMMIT_HASH"
             echo "::error::Merge commit found: $COMMIT_HASH"
+            echo "Merge commit found: $COMMIT_HASH" >> $GITHUB_STEP_SUMMARY
             git show $COMMIT_HASH
             echo "::endgroup::"
           done
+          echo "For guidance on resolving merge commits, please refer to the handling failure messages section of the README.md: https://github.com/motlin/forbid-merge-commits-action#handling-failure-messages" >> $GITHUB_STEP_SUMMARY
           exit 1
         else
           echo "Success: No merge commits found"


### PR DESCRIPTION
Implements the use of `$GITHUB_STEP_SUMMARY` in the `action.yml` file to enhance the action's feedback mechanism for detected merge commits.

- **Summary Logging**: Appends a summary of found merge commits to `$GITHUB_STEP_SUMMARY`, including the commit hash for each detected merge commit. This allows for a consolidated view of all merge commits found during the action's execution.
- **Guidance Link**: Adds a link to the handling failure messages section of the `README.md` in the `$GITHUB_STEP_SUMMARY`. This provides users with immediate access to guidance on resolving merge commits directly from the action's summary output.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/motlin/forbid-merge-commits-action?shareId=962a36ae-7dfc-4b63-bce3-c3babf37c8b1).