### PR TITLE
Fix local test by adding mock PR event payload and yamllint config

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,7 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 256
+  document-start: disable

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ default:
 
 # Run local tests
 test:
-    act pull_request -j forbid-merge-commits
+    act pull_request -j forbid-merge-commits -e test/event-pull-request.json
 
 # Lint the action.yml file
 lint-action:

--- a/test/event-pull-request.json
+++ b/test/event-pull-request.json
@@ -1,0 +1,10 @@
+{
+  "pull_request": {
+    "head": {
+      "sha": "d4d1bd4"
+    },
+    "base": {
+      "ref": "main"
+    }
+  }
+}


### PR DESCRIPTION
The `act` command needs a PR event payload to populate `github.base_ref` and `github.event.pull_request.head.sha`, otherwise the git log range resolves to the invalid `origin/..`.